### PR TITLE
chore(safe): Fix Authentication bypass in Personal API QA-237

### DIFF
--- a/server/start.go
+++ b/server/start.go
@@ -86,6 +86,22 @@ which accepts a path for the resulting pprof file.
 				return err
 			}
 
+			// Security check: prevent personal API from being enabled
+			jsonRPCAPIs := serverCtx.Viper.GetStringSlice(srvflags.JSONRPCAPI)
+			for _, api := range jsonRPCAPIs {
+				api = strings.ToLower(strings.TrimSpace(api))
+				if api == "personal" {
+					return fmt.Errorf(
+						"SECURITY ERROR: Personal API is enabled but has been disabled for security reasons.\n"+
+						"Personal API has authentication bypass vulnerabilities (password ignored in transactions).\n"+
+						"To fix: Remove 'personal' from --json-rpc.api parameter.\n"+
+						"Current APIs: %v\n"+
+						"Reference: Authentication bypass in Personal API (C-02)",
+						jsonRPCAPIs,
+					)
+				}
+			}
+
 			_, err = server.GetPruningOptionsFromFlags(serverCtx.Viper)
 			return err
 		},


### PR DESCRIPTION
Fix Authentication bypass in Personal API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a startup validation that blocks running when the Personal JSON-RPC API is enabled.
  * Provides a clear error message instructing users to remove "personal" from the JSON-RPC API list, including the currently configured APIs.
  * Accepts API names regardless of case or whitespace.
  * If "personal" is not present, startup proceeds as normal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->